### PR TITLE
feat(BUX-116): replaced value with block height and increased cell key width to show xpriv

### DIFF
--- a/src/components/json-view.js
+++ b/src/components/json-view.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexBasis: 'flex-start',
     whiteSpace: 'nowrap',
-    maxWidth: '120px',
+    maxWidth: '600px',
     overflow: 'hidden'
   },
   dataCell: {

--- a/src/components/transactions.js
+++ b/src/components/transactions.js
@@ -13,7 +13,7 @@ export const TransactionsList = ({items}) => {
       <TableHead>
         <TableRow>
           <TableCell>ID</TableCell>
-          <TableCell>Value</TableCell>
+          <TableCell>Block Height</TableCell>
           <TableCell>Date</TableCell>
         </TableRow>
       </TableHead>
@@ -32,9 +32,9 @@ export const TransactionsList = ({items}) => {
               }}
             >
               <TableCell>{transaction.id}</TableCell>
-              <TableCell>{transaction.output_value}</TableCell>
+              <TableCell>{transaction.block_height}</TableCell>
               <TableCell>
-                {format(new Date(transaction.created_at), 'dd/MM/yyyy hh:mm')}
+                {format(new Date(transaction.Model.created_at), 'dd/MM/yyyy hh:mm')}
               </TableCell>
             </TableRow>
             {selectedTransactions.indexOf(transaction.id) !== -1 &&


### PR DESCRIPTION
!!! Requires bux-server with changes from https://github.com/BuxOrg/bux-server/pull/289 !!!

txs list on admin panel before:
<img width="1497" alt="Screenshot 2023-08-28 at 11 17 44" src="https://github.com/BuxOrg/bux-console/assets/123358309/37965b3b-7b08-4810-8c13-a583857c64ca">
txs list on admin panel after:
<img width="1505" alt="Screenshot 2023-08-28 at 11 14 27" src="https://github.com/BuxOrg/bux-console/assets/123358309/565f2191-e7c7-49f6-9bae-3c4adcfdf03e">
tx details for admin before:
<img width="1496" alt="Screenshot 2023-08-28 at 11 18 56" src="https://github.com/BuxOrg/bux-console/assets/123358309/0ca73679-7f0e-4916-ac2f-af4d2f87a351">
tx details for admin after:
<img width="1509" alt="Screenshot 2023-08-28 at 11 15 17" src="https://github.com/BuxOrg/bux-console/assets/123358309/7b8f96c8-92dd-4522-944f-be8041441823">
