### PR TITLE
fix(BUX-115): set empty string as default server url, to make it overridable

### DIFF
--- a/public/config.default.json
+++ b/public/config.default.json
@@ -2,6 +2,6 @@
   "loginTitle": "Sign in to a Bux server",
   "loginSubtitle": "Sign in using your xPriv",
   "transportType": "http",
-  "serverUrl": null,
+  "serverUrl": "",
   "hideServerUrl": false
 }


### PR DESCRIPTION
react-configuration is checking if there is a default value to allow for overriding it, unfortunately null value in default values is treated as non existing, and changes from env-config.json is not applied to it.