### PR TITLE
ci(BUX-582): add check for manual tests

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,0 +1,15 @@
+name: "On pull request"
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  on-pr:
+    uses: bactions/workflows/.github/workflows/on-pull-request.yml@main


### PR DESCRIPTION
1. Goal:
This workflow will perform a check if the `tested` label was set (by someone other then author) to confirm (and remind about) that manual tests should be performed.

We can fully use it when we merge this commit, so we will be able to make add a branch protection rule to require this check to pass, effectively preventing a PR from merging without someone would declare that he perform manual tests.

2. How is it set:
It use a  reusable workflow: https://github.com/bactions/workflows/blob/main/.github/workflows/on-pull-request.yml

To have a full power of it a workflow that is calling it need to be triggered at least on:
```
  pull_request_target:
    types:
      - labeled
      - unlabeled
      - opened
 ```
and to add a comment it need to have 
```
permissions:
  pull-requests: write
```
3. How is it working
 - When the PR is opened, a comment will be added to PR to remind about manual tests.
 - when author tries to add a `tested` label, the check will fail and replace a comment with message that author shouldn't perform manual tests
 - when `tested` label is set by other user check will pass and add a comment about successful manual testing
 - when `tested` label is removed the check will fail again and revert the comment to reminder message about manual testing.

4. How to test it
Create another PR with target branch to this PR, then perform actions from the point 3 on that new PR. Remember that if the check fails it means that later (when the branch protection will be added) this will prevent merging the PR.