### PR TITLE
fix(SPV-990): stringify "outputs" field in view dialog

### DIFF
--- a/src/components/ViewDialog/ViewDialog.tsx
+++ b/src/components/ViewDialog/ViewDialog.tsx
@@ -27,10 +27,10 @@ export const ViewDialog = ({ row }: ViewDialogProps) => {
         return;
       }
 
-      if (field === 'metadata') {
+      if (field === 'metadata' || field === 'outputs') {
         return (
           <div key={field}>
-            <span className="text-gray-400">metadata:</span> {JSON.stringify(value) as React.ReactNode}
+            <span className="text-gray-400">{field}:</span> {JSON.stringify(value) as React.ReactNode}
           </div>
         );
       }


### PR DESCRIPTION
For Admin transactions have "output" field which is a key-value object. Such object should be parsed by JSON.stringify and than cast to ReactNode


**Before:** 
![CleanShot 2024-08-09 at 14 07 00](https://github.com/user-attachments/assets/f2cd991c-882b-416f-8ca0-f10beb4b74e8)


**After:** 
![CleanShot 2024-08-09 at 14 07 36](https://github.com/user-attachments/assets/a7ade208-f973-4178-bd8f-279448c5bf57)

