### PR TITLE
refactor: suggestion how to make actions and inline actions generic

### DIFF
--- a/src/components/ContactsTabContent/ContactsTabContent.tsx
+++ b/src/components/ContactsTabContent/ContactsTabContent.tsx
@@ -1,14 +1,9 @@
-import React from 'react';
-
 import {
+  ActionComponent,
   Card,
   CardContent,
   CardHeader,
   CardTitle,
-  ContactAcceptDialogProps,
-  ContactDeleteDialogProps,
-  ContactEditDialogProps,
-  ContactRejectDialogProps,
   contactsColumns,
   DataTable,
   NoRecordsText,
@@ -17,19 +12,11 @@ import { ContactExtended } from '@/interfaces/contacts.ts';
 
 export interface ContactsTabContentProps {
   contacts: ContactExtended[];
-  ContactEditDialog?: React.ComponentType<ContactEditDialogProps>;
-  AcceptDialog?: React.ComponentType<ContactAcceptDialogProps>;
-  DeleteDialog?: React.ComponentType<ContactDeleteDialogProps>;
-  RejectDialog?: React.ComponentType<ContactRejectDialogProps>;
+  actions: ActionComponent<ContactExtended>[];
+  inlineActions?: ActionComponent<ContactExtended>[];
 }
 
-export const ContactsTabContent = ({
-  contacts,
-  ContactEditDialog,
-  AcceptDialog,
-  DeleteDialog,
-  RejectDialog,
-}: ContactsTabContentProps) => {
+export const ContactsTabContent = ({ contacts, actions, inlineActions }: ContactsTabContentProps) => {
   return (
     <Card>
       <CardHeader>
@@ -37,14 +24,7 @@ export const ContactsTabContent = ({
       </CardHeader>
       <CardContent className="mb-2">
         {contacts.length > 0 ? (
-          <DataTable
-            columns={contactsColumns}
-            data={contacts}
-            AcceptDialog={AcceptDialog}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={DeleteDialog}
-            RejectDialog={RejectDialog}
-          />
+          <DataTable columns={contactsColumns} data={contacts} actions={actions} inlineActions={inlineActions} />
         ) : (
           <NoRecordsText message="No Contacts to show." />
         )}

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -2,52 +2,54 @@ import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
-  useReactTable,
   getPaginationRowModel,
-  SortingState,
   Row,
+  SortingState,
+  useReactTable,
 } from '@tanstack/react-table';
 import { EllipsisVertical } from 'lucide-react';
 
 import React, { useState } from 'react';
 
 import {
-  ContactStatus,
-  ContactDeleteDialogProps,
-  ContactEditDialogProps,
-  ContactAcceptDialogProps,
-  DataTablePagination,
   Button,
+  ContactDeleteDialogProps,
+  ContactStatus,
+  DataTablePagination,
+  DestinationEditDialogProps,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuTrigger,
+  PaymailDeleteDialogProps,
+  RevokeKeyDialogProps,
   Table,
   TableBody,
   TableCell,
   TableHead,
   TableHeader,
   TableRow,
-  ViewDialog,
-  ContactRejectDialogProps,
-  RevokeKeyDialogProps,
   TransactionEditDialogProps,
-  DestinationEditDialogProps,
-  PaymailDeleteDialogProps,
+  ViewDialog,
 } from '@/components';
 import { AccessKey, Contact, Destination, PaymailAddress, Tx, XPub } from '@bsv/spv-wallet-js-client';
 
 export type RowType = XPub | Contact | AccessKey | Destination | PaymailAddress | Tx;
 
+export type RowProps<TData> = {
+  row: Row<TData>;
+};
+
+export type ActionComponent<TData> = React.ComponentType<RowProps<TData>>;
+
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
-  ContactEditDialog?: React.ComponentType<ContactEditDialogProps>;
+  actions?: ActionComponent<TData>[];
+  inlineActions?: ActionComponent<TData>[];
   TransactionEditDialog?: React.ComponentType<TransactionEditDialogProps>;
   DestinationEditDialog?: React.ComponentType<DestinationEditDialogProps>;
-  AcceptDialog?: React.ComponentType<ContactAcceptDialogProps>;
   DeleteDialog?: React.ComponentType<ContactDeleteDialogProps>;
-  RejectDialog?: React.ComponentType<ContactRejectDialogProps>;
   RevokeKeyDialog?: React.ComponentType<RevokeKeyDialogProps>;
   PaymailDeleteDialog?: React.ComponentType<PaymailDeleteDialogProps>;
 }
@@ -57,12 +59,11 @@ const initialSorting = { id: 'id', desc: false };
 export function DataTable<TData, TValue>({
   columns,
   data,
-  ContactEditDialog,
+  actions,
+  inlineActions,
   TransactionEditDialog,
   DestinationEditDialog,
-  AcceptDialog,
   DeleteDialog,
-  RejectDialog,
   RevokeKeyDialog,
   PaymailDeleteDialog,
 }: DataTableProps<TData, TValue>) {
@@ -109,8 +110,7 @@ export function DataTable<TData, TValue>({
                 <TableCell>
                   {table.getColumn('status') && row.getValue('status') === ContactStatus.Awaiting ? (
                     <div className="grid grid-cols-2 items-center w-fit gap-4 ">
-                      {AcceptDialog ? <AcceptDialog row={row as Row<Contact>} /> : null}
-                      {RejectDialog ? <RejectDialog row={row as Row<Contact>} /> : null}
+                      {inlineActions?.map((Action, index) => <Action key={index} row={row} />)}
                     </div>
                   ) : null}
                 </TableCell>
@@ -124,7 +124,7 @@ export function DataTable<TData, TValue>({
                     <DropdownMenuContent align="end">
                       <DropdownMenuLabel>Actions</DropdownMenuLabel>
                       <ViewDialog row={row as Row<RowType>} />
-                      {ContactEditDialog ? <ContactEditDialog row={row as Row<Contact>} /> : null}
+                      {actions?.map((Action, index) => <Action key={index} row={row} />)}
                       {TransactionEditDialog ? <TransactionEditDialog row={row as Row<Tx>} /> : null}
                       {DestinationEditDialog ? <DestinationEditDialog row={row as Row<Destination>} /> : null}
                       {DeleteDialog ? <DeleteDialog row={row as Row<Contact>} /> : null}

--- a/src/routes/admin/_admin.contacts.tsx
+++ b/src/routes/admin/_admin.contacts.tsx
@@ -160,48 +160,28 @@ export function Contacts() {
         <TabsContent value="all">
           <ContactsTabContent
             contacts={contacts}
-            AcceptDialog={ContactAcceptDialog}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={ContactDeleteDialog}
-            RejectDialog={ContactRejectDialog}
+            inlineActions={[ContactAcceptDialog, ContactRejectDialog]}
+            actions={[ContactEditDialog, ContactDeleteDialog]}
           />
         </TabsContent>
         <TabsContent value="unconfirmed">
-          <ContactsTabContent
-            contacts={unconfirmedContacts}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={ContactDeleteDialog}
-          />
+          <ContactsTabContent contacts={unconfirmedContacts} actions={[ContactEditDialog, ContactDeleteDialog]} />
         </TabsContent>
         <TabsContent value="awaiting">
           <ContactsTabContent
             contacts={awaitingContacts}
-            AcceptDialog={ContactAcceptDialog}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={ContactDeleteDialog}
-            RejectDialog={ContactRejectDialog}
+            inlineActions={[ContactAcceptDialog, ContactRejectDialog]}
+            actions={[ContactDeleteDialog]}
           />
         </TabsContent>
         <TabsContent value="confirmed">
-          <ContactsTabContent
-            contacts={confirmedContacts}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={ContactDeleteDialog}
-          />
+          <ContactsTabContent contacts={confirmedContacts} actions={[ContactEditDialog, ContactDeleteDialog]} />
         </TabsContent>
         <TabsContent value="rejected">
-          <ContactsTabContent
-            contacts={rejectedContacts}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={ContactDeleteDialog}
-          />
+          <ContactsTabContent contacts={rejectedContacts} actions={[ContactEditDialog, ContactDeleteDialog]} />
         </TabsContent>
         <TabsContent value="deleted">
-          <ContactsTabContent
-            contacts={deletedContacts}
-            ContactEditDialog={ContactEditDialog}
-            DeleteDialog={ContactDeleteDialog}
-          />
+          <ContactsTabContent contacts={deletedContacts} actions={[ContactEditDialog, ContactDeleteDialog]} />
         </TabsContent>
       </Tabs>
       <Toaster position="bottom-center" />


### PR DESCRIPTION
This is a proposition how we can use actions and inlineActions instead of static actions creation in DataTable
(for now I applied it only to contacts, but I like only to show what I mean in [my comment on PR 989](https://github.com/bitcoin-sv/spv-wallet-admin/pull/989#discussion_r1719522118)